### PR TITLE
Update readme.md

### DIFF
--- a/firmware/V1.2/readme.md
+++ b/firmware/V1.2/readme.md
@@ -4,7 +4,7 @@
 4. In the lower left corner of the VSCode, you can see that there’s one more icon, please see the picture below, 
 which is the PlatformIO plugin, and then click "Open Project" to open the project.![image](https://user-images.githubusercontent.com/25599056/60634053-0aee5d80-9e40-11e9-9658-7cac8b6d1002.png)
 ### If you are using the official Marlin 2.0 version, you need the following additional changes
-* After opening the project, go to the platformio.ini file and change the default environment from megaatmega2560 to STM32F103RC_bigtree_NOUSB, `env_default = STM32F103RC_bigtree_NOUSB`
+* After opening the project, go to the platformio.ini file and change the default environment from megaatmega2560 to STM32F103RC_bigtree_512K, `env_default = STM32F103RC_bigtree_512K`
 * If you use the latest bugfix-2.0.x change the default environment from megaatmega2560 to STM32F103RC_bigtree, `env_default = STM32F103RC_bigtree`
 
  ![image](https://user-images.githubusercontent.com/38851044/69534016-f4de6680-0fb3-11ea-972f-5daae3643061.png)


### PR DESCRIPTION
_NOUSB is not a valid option anymore. Correct version is STM32F103RC_bigtree_512K

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
