### PR TITLE
Update platformio.ini

### DIFF
--- a/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/platformio.ini
+++ b/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = STM32F103RC_bigtree_NOUSB
+default_envs = STM32F103RC_bigtree
 
 [common]
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>


### PR DESCRIPTION
 STM32F103RC_bigtree_NOUSB is not a valid option anymore

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
