### PR TITLE
Changed the default build environment to STM32F103RC_btt

### DIFF
--- a/firmware/V2.0/Marlin-2.0.x-SKR-mini-E3-V2.0/platformio.ini
+++ b/firmware/V2.0/Marlin-2.0.x-SKR-mini-E3-V2.0/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = STM32F103RC_btt_512K
+default_envs = STM32F103RC_btt
 include_dir  = Marlin
 
 #


### PR DESCRIPTION

### Requirements

### Description

There have been reports of processors locking up and driving the heater on the hotend to the maximum level which has resulted in smoke and could have resulted in fire if not attended to immediately. It is believed that using the 512K build environments (which are not approved by the MCU manufacturer) are contributing to these lock ups. This PR changes the default build environment back to the 256k one and leaves the decision to go higher up to the user.

### Benefits

This should ideally help to rectify the lock up incidents.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->

See this link for comments on the issue https://www.facebook.com/groups/505736576548648/permalink/1046495615806072
