### PR TITLE
fix: fan doesn't start unless click on the knob

### DIFF
--- a/firmware/V2.0/Marlin-2.0.7.2-SKR-mini-E3-V2.0/Marlin/Configuration.h
+++ b/firmware/V2.0/Marlin-2.0.7.2-SKR-mini-E3-V2.0/Marlin/Configuration.h
@@ -1807,7 +1807,7 @@
 // If you have a speaker that can produce tones, enable it here.
 // By default Marlin assumes you have a buzzer with a fixed frequency.
 //
-#define SPEAKER
+//#define SPEAKER
 
 //
 // The duration and frequency for the UI feedback sound.


### PR DESCRIPTION
### Requirements

BTT SKR mini E3 V2.0 with the latest firmware

### Description

Go to "Temperature > Fan speed" and choose 100% and click on the knob to validate. The fan doesn't start until I click the knob once again.
This has the same behavior when passing to 0%.

It seems it could be fixed by disabling the speaker option.

### Benefits

The fan starts immediately after clicking the knob only one time.

### Related issues
- Maybe #447 ?