### PR TITLE
Added a support for the ANET_FULL_GRAPHICS_LCD

### DIFF
--- a/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -162,6 +162,40 @@
     #define LCD_PINS_D7                     PB5
     #define ADC_KEYPAD_PIN                  PA1   // Repurpose servo pin for ADC - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
+  #elif ENABLED(ANET_FULL_GRAPHICS_LCD)           // ANET A6 LCD FULL GRAPHICS Controller
+    
+    /* 1. Cut the tab off the SKR MINI connector so it can be plugged into the LCD connector the other way. (180 degrees flip)
+    * 2. Swap the LCD's +5V (Pin2) and GND (Pin1) wires. (This is the critical part!)
+    * 3. A wire is needed to connect the Reset switch at J3 (LCD Pin7).
+    *
+    * !!! If you are unsure, ask for help! Your motherboard may be damaged in some circumstances !!!
+    *
+    * The ANET_FULL_GRAPHICS_LCD connector plug:
+    *
+    *                     BEFORE                                   AFTER                            AFTER
+    *                     ______                                   ______                           ______
+    *               5V 1 | 1  2 |  2 GND                    GND 1 | 1  2 |  2 5V                   | 1  2 |
+    *      LCD_PINS_RS 3 | 3  4 |  4 BTN_EN2        LCD_PINS_RS 3 | 3  4 |  4 BTN_EN2              | 3  4 |
+    *  LCD_PINS_ENABLE 5   5  6 |  6 BTN_EN1    LCD_PINS_ENABLE 5   5  6 |  6 BTN_EN1                5  6 |
+    *             open 7 | 7  8 |  8 BTN_ENC               open 7 | 7  8 |  8 BTN_ENC      RESET 7 | 7  8 |
+    *      LCD_PINS_D4 9 | 9 10 | 10 BEEPER_PIN     LCD_PINS_D4 9 | 9 10 | 10 BEEPER_PIN           | 9 10 |
+    *                     ------                                   ------                           ------
+    *                      LCD                                      LCD                               J3
+    */
+
+    #error "CAUTION! ANET_FULL_GRAPHICS_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. Comment out this line to continue."
+
+    #define LCD_PINS_RS              PB15
+
+    #define BTN_EN1                  PA10 //Rx1
+    #define BTN_EN2                  PB8
+    #define BTN_ENC                  PA9 //Tx1
+
+    #define LCD_PINS_ENABLE          PB9
+    #define LCD_PINS_D4              PA15
+
+    #define BEEPER_PIN               PB5
+
   #elif EITHER(MKS_MINI_12864, ENDER2_STOCKDISPLAY)
 
     #define BTN_ENC                       EXP1_9
@@ -216,7 +250,7 @@
     #endif
 
   #else
-    #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, and TFTGLCD_PANEL_(SPI|I2C) are currently supported on the BIGTREE_SKR_MINI_E3."
+    #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, TFTGLCD_PANEL_(SPI|I2C) and ANET_FULL_GRAPHICS_LCD are currently supported on the BIGTREE_SKR_MINI_E3."
   #endif
 
 #endif // HAS_WIRED_LCD


### PR DESCRIPTION
### Description
Added an Anet A6 FULL GRAPHICS LCD support + mini tutorial how to rewire wires.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->
It adds a support for Anet A6 FULL GRAPHICS LCD12864, users can easily use stock Anet A6 LCD with a little amount of rewiring (just 5v and GND)
### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
