### PR TITLE
Fix pin declaration for bltouch

### DIFF
--- a/firmware/V3.0/Klipper/SKR-mini-E3-V3.0-klipper.cfg
+++ b/firmware/V3.0/Klipper/SKR-mini-E3-V3.0-klipper.cfg
@@ -10,7 +10,7 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [bltouch]
-sensor_pin: PC14
+sensor_pin: ^PC14
 control_pin: PA1
 x_offset: -40
 y_offset: -10


### PR DESCRIPTION
### Description
Adding '^' enables the built-in hardware pull-up resistor for the pin. 

### Benefits

Using '^' will make sure the bl touch functions as expected.
Without it the sensor will not be able to detect anything.

### Related Issues
This fixes #616 
