### PR TITLE
Updated BL Touch PIN for CR touch

### DIFF
--- a/firmware/V3.0/Klipper/SKR-mini-E3-V3.0-klipper.cfg
+++ b/firmware/V3.0/Klipper/SKR-mini-E3-V3.0-klipper.cfg
@@ -10,7 +10,7 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [bltouch]
-sensor_pin: PC14
+sensor_pin: ^PC14
 control_pin: PA1
 x_offset: -40
 y_offset: -10


### PR DESCRIPTION
Here is a updated version of the config with the bl touch pin so the CR touch work again. [Issue]:
Z axis crashing into bed and cr touch didnt worked .

[Solution]
Adding a little ^ to the Pin make the cr touch working (could be different for other abl models

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
