### PR TITLE
Fixed Compile issue with Updated PlatformIO

### DIFF
--- a/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/buildroot/share/PlatformIO/scripts/marlin.py
@@ -17,7 +17,7 @@ def copytree(src, dst, symlinks=False, ignore=None):
             shutil.copy2(s, d)
 
 def replace_define(field, value):
-	for define in env['CPPDEFINES']:
+	for define in env['CPPDEFINES'].copy():
 		if define[0] == field:
 			env['CPPDEFINES'].remove(define)
 	env['CPPDEFINES'].append((field, value))


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

Due to an update older versions of Marlin are unable to compile if using platformIO, this is fixed in Marlin 2.1.*. However, due to the old age of this firmware it hasn't been updated here.
-->

### Benefits

Actually allows your code to compile if using PlatformIO