### PR TITLE
Fixed CR Touch Probe pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ Disclaimer! Marlin firmware needs to be configured aND CUSTOMIZED by the custome
  ## History
  
  - 18-21th of May - Added BTT SKR Mini E3 v2.0 motherboard firmware and related open source materials.
+
+##This Fork Includes:
+Fix for Cr Touch Crashing into bed
+

--- a/firmware/V3.0/Klipper/SKR-mini-E3-V3.0-klipper.cfg
+++ b/firmware/V3.0/Klipper/SKR-mini-E3-V3.0-klipper.cfg
@@ -10,7 +10,7 @@
 # See docs/Config_Reference.md for a description of parameters.
 
 [bltouch]
-sensor_pin: PC14
+sensor_pin: ^PC14 #Remove ^ if print head crashes into bed
 control_pin: PA1
 x_offset: -40
 y_offset: -10


### PR DESCRIPTION
Updated BL Touch PIN for CR touch
Here is a updated version of the config with the bl touch pin so the CR touch work again.
[Issue]:
Z axis crashing into bed and cr touch didnt worked .

[Solution]
Adding a little ^ to the Pin